### PR TITLE
(SIMP-2427) Rename to simp_openldap

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -21,4 +21,4 @@ fixtures:
     stunnel: https://github.com/simp/pupmod-simp-stunnel
     tcpwrappers: https://github.com/simp/pupmod-simp-tcpwrappers
   symlinks:
-    openldap: "#{source_dir}"
+    simp_openldap: "#{source_dir}"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed Jan 25 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.0-0
+- Rename from 'openldap' to 'simp_openldap' so that we can migrate to an
+  alternate backend in the future
+
 * Mon Jan 23 2017 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.0-0
 - Calls to rsyslog::rule no longer contain 'if' logic
 

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,4 +1,6 @@
 # Drop all Requires, Obsoletes, and Provides statements in here
+Obsoletes: pupmod-simp-openldap >= 6.0.0-0
+Provides: pupmod-simp-openldap = %{version}
 Obsoletes: pupmod-openldap-test >= 0.0.1
 Requires: pupmod-simp-auditd < 8.0.0-0
 Requires: pupmod-simp-auditd >= 7.0.0-0

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -29,23 +29,23 @@
 # @param app_pki_crl
 #   Path to the CRL file.
 #
-class openldap::client (
-  Array[Simplib::URI]                          $uri                 = $::openldap::_ldap_uri,
-  Optional[String]                             $base_dn             = $::openldap::base_dn,
-  String[1]                                    $bind_dn             = $::openldap::bind_dn,
+class simp_openldap::client (
+  Array[Simplib::URI]                          $uri                 = $::simp_openldap::_ldap_uri,
+  Optional[String]                             $base_dn             = $::simp_openldap::base_dn,
+  String[1]                                    $bind_dn             = $::simp_openldap::bind_dn,
   Enum['on','off']                             $referrals           = 'on',
   Integer                                      $sizelimit           = 0,
   Integer                                      $timelimit           = 15,
-  Variant[Enum['simp'],Boolean]                $use_tls             = $::openldap::pki,
-  Stdlib::Absolutepath                         $app_pki_ca_dir      = $::openldap::app_pki_ca_dir,
-  Stdlib::Absolutepath                         $app_pki_cert        = $::openldap::app_pki_cert,
-  Stdlib::Absolutepath                         $app_pki_key         = $::openldap::app_pki_key,
-  Optional[Stdlib::Absolutepath]               $app_pki_crl         = $::openldap::app_pki_crl,
+  Variant[Enum['simp'],Boolean]                $use_tls             = $::simp_openldap::pki,
+  Stdlib::Absolutepath                         $app_pki_ca_dir      = $::simp_openldap::app_pki_ca_dir,
+  Stdlib::Absolutepath                         $app_pki_cert        = $::simp_openldap::app_pki_cert,
+  Stdlib::Absolutepath                         $app_pki_key         = $::simp_openldap::app_pki_key,
+  Optional[Stdlib::Absolutepath]               $app_pki_crl         = $::simp_openldap::app_pki_crl,
   Array[String[1]]                             $tls_cipher_suite    = simplib::lookup('simp_options::openssl::cipher_suite', { 'default_value' => ['DEFAULT','!MEDIUM'] }),
   Enum['none','peer','all']                    $tls_crlcheck        = 'none',
   Enum['never','searching','finding','always'] $deref               = 'never',
   Enum['never','allow','try','demand','hard']  $tls_reqcert         = 'allow'
-) inherits ::openldap {
+) inherits ::simp_openldap {
 
   file { '/etc/openldap/ldap.conf':
     owner   => 'root',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,7 +61,7 @@
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-class openldap (
+class simp_openldap (
   Array[Simplib::URI]            $ldap_uri                = simplib::lookup('simp_options::ldap::uri', { 'default_value' => undef }),
   String                         $base_dn                 = simplib::lookup('simp_options::ldap::base_dn', { 'default_value' => simplib::ldap::domain_to_dn() }),
   String                         $bind_dn                 = simplib::lookup('simp_options::ldap::bind_dn', { 'default_value' => sprintf('cn=hostAuth,ou=Hosts,%s', simplib::ldap::domain_to_dn()) }),
@@ -94,14 +94,14 @@ class openldap (
   }
 
   if $is_server {
-    contain '::openldap::server'
+    contain '::simp_openldap::server'
 
     if $pki {
-      Class['pki::copy'] ~> Class['openldap::server::service']
+      Class['pki::copy'] ~> Class['simp_openldap::server::service']
     }
   }
 
-  contain '::openldap::client'
+  contain '::simp_openldap::client'
 
   if $pki {
     pki::copy { 'openldap':

--- a/manifests/server/access.pp
+++ b/manifests/server/access.pp
@@ -25,7 +25,7 @@
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-define openldap::server::access (
+define simp_openldap::server::access (
   String           $what,
   Optional[String] $comment = undef,
   Optional[String] $who     = undef,
@@ -40,7 +40,7 @@ define openldap::server::access (
     mode           => '0640',
     ensure_newline => true,
     warn           => true,
-    notify         => Class['openldap::server::service']
+    notify         => Class['simp_openldap::server::service']
   })
 
   unless ($who or $content) {

--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -217,14 +217,14 @@
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-class openldap::server::conf (
+class simp_openldap::server::conf (
   Optional[String[1]]                                 $rootpw                     = simplib::lookup('simp_options::ldap::root_hash', { 'default_value' => undef }),
   Optional[String[1]]                                 $syncpw                     = simplib::lookup('simp_options::ldap::sync_hash', { 'default_value' => undef }),
   Optional[String[1]]                                 $bindpw                     = simplib::lookup('simp_options::ldap::bind_hash', { 'default_value' => undef }),
-  String[1]                                           $syncdn                     = simplib::lookup('simp_options::ldap::sync_dn', { 'default_value' => "LDAPSync,ou=People,${::openldap::base_dn}" }),
-  String[1]                                           $binddn                     = simplib::lookup('simp_options::ldap::bind_dn', { 'default_value' => $::openldap::bind_dn }),
-  Optional[String[1]]                                 $rootdn                     = simplib::lookup('simp_options::ldap::root_dn', { 'default_value' => "LDAPAdmin,ou=People,${::openldap::base_dn}" }),
-  String[1]                                           $suffix                     = $::openldap::base_dn,
+  String[1]                                           $syncdn                     = simplib::lookup('simp_options::ldap::sync_dn', { 'default_value' => "LDAPSync,ou=People,${::simp_openldap::base_dn}" }),
+  String[1]                                           $binddn                     = simplib::lookup('simp_options::ldap::bind_dn', { 'default_value' => $::simp_openldap::bind_dn }),
+  Optional[String[1]]                                 $rootdn                     = simplib::lookup('simp_options::ldap::root_dn', { 'default_value' => "LDAPAdmin,ou=People,${::simp_openldap::base_dn}" }),
+  String[1]                                           $suffix                     = $::simp_openldap::base_dn,
   Stdlib::Absolutepath                                $argsfile                   = '/var/run/openldap/slapd.args',
   Boolean                                             $audit_transactions         = true,
   Boolean                                             $audit_to_syslog            = true,
@@ -238,7 +238,7 @@ class openldap::server::conf (
       replace => String[1]
   }] ]                                                $authz_regexp               = [{
                                                           'match'   => '^uid=([^,]+),.*',
-                                                          'replace' => "uid=\$1,ou=People,${::openldap::base_dn}"
+                                                          'replace' => "uid=\$1,ou=People,${::simp_openldap::base_dn}"
                                                         }],
   Integer[1]                                          $cachesize                  = 10000,
   Pattern['(^\d+\s\d+$|^$)']                          $checkpoint                 = '1024 5',
@@ -248,13 +248,13 @@ class openldap::server::conf (
   Integer[1]                                          $conn_max_pending_auth      = 100,
   Array[String[1]]                                    $default_schemas            = [ 'openssh-lpk', 'freeradius', 'autofs' ],
   Optional[String[1]]                                 $default_searchbase         = undef,
-  Array[Openldap::SlapdConf::Disallow]                $disallow                   = ['bind_anon','tls_2_anon'],
+  Array[Simp_Openldap::SlapdConf::Disallow]                $disallow                   = ['bind_anon','tls_2_anon'],
   Boolean                                             $force_log_quick_kill       = false,
   Optional[String[1]]                                 $ditcontentrule             = undef,
   Boolean                                             $gentlehup                  = false,
   Integer[0]                                          $idletimeout                = 0,
   Boolean                                             $include_chain_overlay      = false,
-  Optional[String[1]]                                 $master                     = $::openldap::_ldap_master,
+  Optional[String[1]]                                 $master                     = $::simp_openldap::_ldap_master,
   Integer[0]                                          $index_substr_any_step      = 2,
   Integer[0]                                          $index_substr_any_len       = 4,
   Integer[0]                                          $index_substr_if_maxlen     = 4,
@@ -264,7 +264,7 @@ class openldap::server::conf (
   Boolean                                             $listen_ldapi               = true,
   Boolean                                             $listen_ldaps               = true,
   Array[String]                                       $custom_options             = [],
-  Array[Openldap::LogLevel]                           $slapd_log_level            = ['stats', 'acl', 'sync'],
+  Array[Simp_Openldap::LogLevel]                           $slapd_log_level            = ['stats', 'acl', 'sync'],
   String[1]                                           $password_crypt_salt_format = '%s',
   Enum['SSHA','SHA','SMD5','MD5','CRYPT','CLEARTEXT'] $password_hash              = 'SSHA',
   Stdlib::Absolutepath                                $pidfile                    = '/var/run/openldap/slapd.pid',
@@ -285,11 +285,11 @@ class openldap::server::conf (
   Optional[Variant[Enum['unlimited'], Integer[1]]]    $timelimit_soft             = undef,
   Optional[Variant[Enum['unlimited'], Integer[1]]]    $timelimit_hard             = undef,
   Integer[0]                                          $writetimeout               = 0,
-  Variant[Enum['simp'],Boolean]                       $use_tls                    = $::openldap::pki,
-  Stdlib::Absolutepath                                $app_pki_ca_dir             = $::openldap::app_pki_ca_dir,
-  Stdlib::Absolutepath                                $app_pki_cert               = $::openldap::app_pki_cert,
-  Stdlib::Absolutepath                                $app_pki_key                = $::openldap::app_pki_key,
-  Optional[Stdlib::Absolutepath]                      $app_pki_crl                = $::openldap::app_pki_crl,
+  Variant[Enum['simp'],Boolean]                       $use_tls                    = $::simp_openldap::pki,
+  Stdlib::Absolutepath                                $app_pki_ca_dir             = $::simp_openldap::app_pki_ca_dir,
+  Stdlib::Absolutepath                                $app_pki_cert               = $::simp_openldap::app_pki_cert,
+  Stdlib::Absolutepath                                $app_pki_key                = $::simp_openldap::app_pki_key,
+  Optional[Stdlib::Absolutepath]                      $app_pki_crl                = $::simp_openldap::app_pki_crl,
   Array[String[1]]                                    $tls_cipher_suite           = simplib::lookup('simp_options::openssl::cipher_suite' ,{ 'default_value' => ['DEFAULT', '!MEDIUM'] }),
   Enum['none','peer','all']                           $tls_crl_check              = 'none',
   # lint:ignore:quoted_booleans
@@ -317,9 +317,9 @@ class openldap::server::conf (
   Stdlib::Absolutepath                                $log_file                   = '/var/log/slapd.log',
   Boolean                                             $forward_all_logs           = false,
   Boolean                                             $firewall                   = simplib::lookup('simp_options::firewall', {'default_value' => false }),
-) inherits ::openldap {
+) inherits ::simp_openldap {
 
-  include '::openldap::server::conf::default_ldif'
+  include '::simp_openldap::server::conf::default_ldif'
 
   if $force_log_quick_kill {
     include '::incron'
@@ -337,7 +337,7 @@ class openldap::server::conf (
     group   => 'ldap',
     mode    => '0640',
     content => template("${module_name}/etc/openldap/slapd.conf.erb"),
-    notify  => Class['openldap::server::service']
+    notify  => Class['simp_openldap::server::service']
   }
 
   file { '/etc/openldap/DB_CONFIG':
@@ -346,7 +346,7 @@ class openldap::server::conf (
     group   => 'ldap',
     mode    => '0640',
     content => template("${module_name}/etc/openldap/DB_CONFIG.erb"),
-    notify  => Class['openldap::server::service']
+    notify  => Class['simp_openldap::server::service']
   }
 
   if ($facts['os']['name'] in ['RedHat','CentOS']) and (versioncmp($facts['os']['release']['major'], '6') > 0) {
@@ -356,7 +356,7 @@ class openldap::server::conf (
       group   => 'root',
       mode    => '0640',
       content => template("${module_name}/etc/sysconfig/slapd.erb"),
-      notify  => Class['openldap::server::service']
+      notify  => Class['simp_openldap::server::service']
     }
   }
   else {
@@ -366,7 +366,7 @@ class openldap::server::conf (
       group   => 'root',
       mode    => '0640',
       content => template("${module_name}/etc/sysconfig/ldap.erb"),
-      notify  => Class['openldap::server::service']
+      notify  => Class['simp_openldap::server::service']
     }
   }
 
@@ -409,7 +409,7 @@ class openldap::server::conf (
         rotate        => $auditlog_preserve
       }
 
-      openldap::server::dynamic_include { 'auditlog':
+      simp_openldap::server::dynamic_include { 'auditlog':
         order   => 1000,
         content => template("${module_name}/slapo/auditlog.erb"),
         require => File[$auditlog]

--- a/manifests/server/conf/default_ldif.pp
+++ b/manifests/server/conf/default_ldif.pp
@@ -6,7 +6,7 @@
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-class openldap::server::conf::default_ldif (
+class simp_openldap::server::conf::default_ldif (
   Integer[0] $ppolicy_pwd_min_age                = 86400,
   Integer[1] $ppolicy_pwd_max_age                = 15552000,
   Integer[0] $ppolicy_pwd_in_history             = 24,
@@ -25,18 +25,18 @@ class openldap::server::conf::default_ldif (
 
   assert_private()
 
-  $_suffix = $::openldap::server::conf::suffix
-  $_rootdn = $::openldap::server::conf::rootdn
-  $_syncdn = $::openldap::server::conf::syncdn
-  $_syncpw = $::openldap::server::conf::syncpw
-  $_binddn = $::openldap::server::conf::binddn
-  $_bindpw = $::openldap::server::conf::bindpw
+  $_suffix = $::simp_openldap::server::conf::suffix
+  $_rootdn = $::simp_openldap::server::conf::rootdn
+  $_syncdn = $::simp_openldap::server::conf::syncdn
+  $_syncpw = $::simp_openldap::server::conf::syncpw
+  $_binddn = $::simp_openldap::server::conf::binddn
+  $_bindpw = $::simp_openldap::server::conf::bindpw
 
   if (
-    defined('$::openldap::slapo::ppolicy::_check_password') and
-    getvar('::openldap::slapo::ppolicy::_check_password')
+    defined('$::simp_openldap::slapo::ppolicy::_check_password') and
+    getvar('::simp_openldap::slapo::ppolicy::_check_password')
   ) {
-    $_simp_ppolicy_check_password = getvar('::openldap::slapo::ppolicy::_check_password')
+    $_simp_ppolicy_check_password = getvar('::simp_openldap::slapo::ppolicy::_check_password')
   }
   else {
     $_simp_ppolicy_check_password = undef

--- a/manifests/server/dynamic_include.pp
+++ b/manifests/server/dynamic_include.pp
@@ -11,7 +11,7 @@
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-define openldap::server::dynamic_include (
+define simp_openldap::server::dynamic_include (
   String  $content,
   Integer $order = 100
 ) {
@@ -21,7 +21,7 @@ define openldap::server::dynamic_include (
     mode           => '0640',
     ensure_newline => true,
     warn           => true,
-    notify         => Class['openldap::server::service']
+    notify         => Class['simp_openldap::server::service']
   })
 
   concat::fragment { "openldap_dynamic_include_${name}":

--- a/manifests/server/fix_bad_upgrade.pp
+++ b/manifests/server/fix_bad_upgrade.pp
@@ -9,7 +9,7 @@
 #
 # This pops up in the RPM updates from time to time
 #
-class openldap::server::fix_bad_upgrade {
+class simp_openldap::server::fix_bad_upgrade {
   assert_private()
 
   exec { 'fix_bad_upgrade':

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -7,7 +7,7 @@
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-class openldap::server::install (
+class simp_openldap::server::install (
   Enum['latest','installed','present'] $ensure = 'latest'
 ){
   package { 'openldap': ensure => $ensure }

--- a/manifests/server/limits.pp
+++ b/manifests/server/limits.pp
@@ -21,7 +21,7 @@
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-define openldap::server::limits (
+define simp_openldap::server::limits (
   String                        $who,
   Variant[Array[String],String] $limits
 ) {
@@ -32,7 +32,7 @@ define openldap::server::limits (
     $_limits = $limits
   }
 
-  openldap::server::dynamic_include { "limit_${name}":
+  simp_openldap::server::dynamic_include { "limit_${name}":
     content => "limits ${who} ${_limits}"
   }
 }

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -5,12 +5,12 @@
 # @param slapd_svc
 #   The actual service name
 #
-class openldap::server::service (
+class simp_openldap::server::service (
   String[1] $slapd_svc = 'slapd'
 ){
   assert_private()
 
-  include '::openldap::server::fix_bad_upgrade'
+  include '::simp_openldap::server::fix_bad_upgrade'
 
   # This is a very crude attempt to not bootstrap if the executing node is a
   # slave node. Bootstrapping slave nodes causes the ``administrators`` group
@@ -49,6 +49,6 @@ class openldap::server::service (
     enable     => true,
     hasrestart => true,
     hasstatus  => true,
-    require    => Class['openldap::server::fix_bad_upgrade']
+    require    => Class['simp_openldap::server::fix_bad_upgrade']
   }
 }

--- a/manifests/server/syncrepl.pp
+++ b/manifests/server/syncrepl.pp
@@ -8,7 +8,7 @@
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-define openldap::server::syncrepl (
+define simp_openldap::server::syncrepl (
   String[1]                               $syncrepl_retry = '60 10 600 +',
   Optional[String[1]]                     $provider       = simplib::lookup('simp_options::ldap::master', { 'default_value'  => undef }),
   Optional[String[1]]                     $searchbase     = simplib::lookup('simp_options::ldap::base_dn', { 'default_value' => undef }),
@@ -51,7 +51,7 @@ define openldap::server::syncrepl (
 
   validate_re_array(split($syncrepl_retry,'(\d+ \d+)'),'^(\s*(\d+ (\d+|\+)\s*)|\s*)$')
 
-  openldap::server::dynamic_include { 'syncrepl':
+  simp_openldap::server::dynamic_include { 'syncrepl':
     content => template("${module_name}/syncrepl.erb")
   }
 }

--- a/manifests/slapo/lastbind.pp
+++ b/manifests/slapo/lastbind.pp
@@ -8,7 +8,7 @@
 # @author Nick Markowski <nmarkowski@keywcorp.com>
 # @author Kendall Moore <kmoore@keywcorp.com>
 #
-class openldap::slapo::lastbind (
+class simp_openldap::slapo::lastbind (
   Integer[0] $lastbind_precision = 3600
 ) {
   package { 'simp-lastbind': ensure => 'latest' }
@@ -21,7 +21,7 @@ class openldap::slapo::lastbind (
     require => Package['simp-lastbind']
   }
 
-  openldap::server::dynamic_include { 'lastbind':
+  simp_openldap::server::dynamic_include { 'lastbind':
     order   => 1000,
     content => "moduleload lastbind.so\noverlay lastbind\n",
     require => Package['simp-lastbind']

--- a/manifests/slapo/ppolicy.pp
+++ b/manifests/slapo/ppolicy.pp
@@ -37,8 +37,8 @@
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-class openldap::slapo::ppolicy (
-  Optional[String[1]] $suffix                    = $::openldap::base_dn,
+class simp_openldap::slapo::ppolicy (
+  Optional[String[1]] $suffix                    = $::simp_openldap::base_dn,
   Optional[String[1]] $ppolicy_default           = undef,
   Optional[String[1]] $ppolicy_hash_cleartext    = undef,
   Optional[String[1]] $ppolicy_use_lockout       = undef,
@@ -49,12 +49,12 @@ class openldap::slapo::ppolicy (
   Integer[0]          $min_digit                 = 0,
   Integer[0]          $min_punct                 = 0,
   Integer[0]          $max_consecutive_per_class = 3
-) inherits ::openldap {
+) inherits ::simp_openldap {
   $_check_password = 'simp_check_password'
 
   package { 'simp-ppolicy-check-password': ensure => 'latest' }
 
-  openldap::server::dynamic_include { 'ppolicy':
+  simp_openldap::server::dynamic_include { 'ppolicy':
     order   => 1000,
     content => template("${module_name}/slapo/ppolicy.erb")
   }

--- a/manifests/slapo/syncprov.pp
+++ b/manifests/slapo/syncprov.pp
@@ -4,7 +4,7 @@
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-class openldap::slapo::syncprov (
+class simp_openldap::slapo::syncprov (
   Optional[Pattern['^\d+\s\d+$']]     $checkpoint           = undef,
   Optional[String[1]]                 $sessionlog           = undef,
   Boolean                             $nopresent            = false,
@@ -14,15 +14,15 @@ class openldap::slapo::syncprov (
   Variant[Enum['unlimited'], Integer] $sync_time_soft_limit = 'unlimited',
   Variant[Enum['unlimited'], Integer] $sync_time_hard_limit = 'unlimited'
 ) {
-  include '::openldap::server'
+  include '::simp_openldap::server'
 
-  openldap::server::dynamic_include { 'syncprov':
+  simp_openldap::server::dynamic_include { 'syncprov':
     order   => 1000,
     content => template("${module_name}/slapo/syncprov.erb")
   }
 
-  openldap::server::limits { 'Allow Sync User Unlimited':
-    who    => $::openldap::server::sync_dn,
+  simp_openldap::server::limits { 'Allow Sync User Unlimited':
+    who    => $::simp_openldap::server::sync_dn,
     limits => [
       "size.soft=${sync_size_soft_limit}",
       "size.hard=${sync_size_hard_limit}",

--- a/metadata.json
+++ b/metadata.json
@@ -1,11 +1,11 @@
 {
-  "name": "simp-openldap",
+  "name": "simp-simp_openldap",
   "version": "6.0.0",
   "author": "SIMP Team",
   "summary": "Manages OpenLDAP and related security bindings",
   "license": "Apache-2.0",
-  "source": "https://github.com/simp/pupmod-simp-openldap",
-  "project_page": "https://github.com/simp/pupmod-simp-openldap",
+  "source": "https://github.com/simp/pupmod-simp-simp_openldap",
+  "project_page": "https://github.com/simp/pupmod-simp-simp_openldap",
   "issues_url": "https://simp-project.atlassian.net",
   "tags": [
     "simp",

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper_acceptance'
 require 'erb'
 
-test_name 'openldap class'
+test_name 'simp_openldap class'
 
-describe 'openldap class' do
+describe 'simp_openldap class' do
   before(:context) do
     hosts.each do |host|
       interfaces = fact_on(host, 'interfaces').strip.split(',')
@@ -24,12 +24,12 @@ describe 'openldap class' do
 
   let(:server_manifest) {
     <<-EOS
-      include 'openldap::server'
+      include 'simp_openldap::server'
     EOS
   }
 
   servers.each do |server|
-    context "openldap::server #{server}" do
+    context "simp_openldap::server #{server}" do
       let(:server_fqdn) { fact_on(server, 'fqdn') }
       let(:base_dn) { fact_on(server, 'domain').split('.').map{ |d| "dc=#{d}" }.join(',') }
 

--- a/spec/acceptance/suites/default/templates/server_hieradata.yaml.erb
+++ b/spec/acceptance/suites/default/templates/server_hieradata.yaml.erb
@@ -7,8 +7,8 @@ simp_options::tcpwrappers: false
 simp_options::sssd: false
 simp_options::syslog: false
 
-openldap::server::conf::default_ldif::ppolicy_pwd_min_age: 0
-openldap::server::conf::default_ldif::ppolicy_pwd_failure_count_interval: 4
+simp_openldap::server::conf::default_ldif::ppolicy_pwd_min_age: 0
+simp_openldap::server::conf::default_ldif::ppolicy_pwd_failure_count_interval: 4
 
 simp_options::ldap::uri:
   - 'ldap://<%= server_fqdn %>'

--- a/spec/acceptance/suites/default/templates/server_hieradata_tls.yaml.erb
+++ b/spec/acceptance/suites/default/templates/server_hieradata_tls.yaml.erb
@@ -8,8 +8,8 @@ simp_options::syslog: false
 simp_options::pki: true
 simp_options::pki::source: '/etc/pki/simp-testing/pki'
 
-openldap::server::conf::default_ldif::ppolicy_pwd_min_age: 0
-openldap::server::conf::default_ldif::ppolicy_pwd_failure_count_interval: 4
+simp_openldap::server::conf::default_ldif::ppolicy_pwd_min_age: 0
+simp_openldap::server::conf::default_ldif::ppolicy_pwd_failure_count_interval: 4
 
 simp_options::ldap::uri:
   - 'ldap://<%= server_fqdn %>'

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -62,15 +62,15 @@ ldaprc_content = {
 
 shared_examples_for "a ldap config generator" do
   it { is_expected.to compile.with_all_deps }
-  it { is_expected.to create_class('openldap') }
-  it { is_expected.to create_class('openldap::client') }
+  it { is_expected.to create_class('simp_openldap') }
+  it { is_expected.to create_class('simp_openldap::client') }
   it { is_expected.to create_file('/etc/openldap/ldap.conf').with_content( ldap_conf_content[content_option] ) }
   it { is_expected.to create_file('/root/.ldaprc').with_content( ldaprc_content[content_option] ) }
   it { is_expected.to create_package('nss-pam-ldapd') }
   it { is_expected.to create_package("openldap-clients.#{facts[:hardwaremodel]}") }
 end
 
-describe 'openldap::client' do
+describe 'simp_openldap::client' do
 
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'openldap' do
+describe 'simp_openldap' do
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
       context "on #{os}" do
@@ -12,7 +12,7 @@ describe 'openldap' do
           facts
         end
 
-        it { is_expected.to create_class('openldap') }
+        it { is_expected.to create_class('simp_openldap') }
         it { is_expected.to compile.with_all_deps }
 
         context 'is_server' do
@@ -20,7 +20,7 @@ describe 'openldap' do
             :is_server => true
           }}
 
-          it { is_expected.to create_class('openldap::server') }
+          it { is_expected.to create_class('simp_openldap::server') }
         end
       end
     end

--- a/spec/classes/server/conf_spec.rb
+++ b/spec/classes/server/conf_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'openldap::server::conf' do
+describe 'simp_openldap::server::conf' do
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
       context "on #{os}" do
@@ -14,15 +14,15 @@ describe 'openldap::server::conf' do
 
         let(:pre_condition) {
           %(
-            class { "::openldap":
+            class { "::simp_openldap":
               base_dn   => "dc=host,dc=net",
               is_server => true
             }
           )
         }
 
-        it { is_expected.to create_class('openldap::server') }
-        it { is_expected.to create_class('openldap::server::conf::default_ldif') }
+        it { is_expected.to create_class('simp_openldap::server') }
+        it { is_expected.to create_class('simp_openldap::server::conf::default_ldif') }
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to create_file('/etc/openldap/DB_CONFIG').with_content(/set_data_dir/) }
@@ -38,37 +38,37 @@ describe 'openldap::server::conf' do
         }
 
         context 'with pki = false' do
-          let(:pre_condition) { "include 'openldap'" }
+          let(:pre_condition) { "include 'simp_openldap'" }
           let(:hieradata) { 'pki_false' }
           it { is_expected.to_not contain_class('pki') }
           it { is_expected.to_not create_pki__copy('openldap') }
           it { is_expected.to_not create_file('/etc/pki/simp_apps/openldap/x509')}
-          it { is_expected.to create_file('/etc/openldap/slapd.conf').with_notify('Class[Openldap::Server::Service]') }
+          it { is_expected.to create_file('/etc/openldap/slapd.conf').with_notify('Class[Simp_openldap::Server::Service]') }
           it { is_expected.to create_file('/etc/openldap/slapd.conf').without_content(/TLSCertificateFile/) }
         end
 
         context 'with pki = true' do
-          let(:pre_condition) { "include 'openldap'" }
+          let(:pre_condition) { "include 'simp_openldap'" }
           let(:hieradata) { 'pki_true' }
           it { is_expected.to_not contain_class('pki') }
           it { is_expected.to create_pki__copy('openldap') }
           it { is_expected.to create_file('/etc/pki/simp_apps/openldap/x509')}
           it { is_expected.to create_file('/etc/openldap/slapd.conf').with({
-            :notify => 'Class[Openldap::Server::Service]',
+            :notify => 'Class[Simp_openldap::Server::Service]',
             :content => /TLSCertificateFile/
             })
           }
         end
 
         context 'with pki = simp' do
-          let(:pre_condition) { "include 'openldap'" }
+          let(:pre_condition) { "include 'simp_openldap'" }
           let(:hieradata) { 'pki_simp' }
           let(:params) {{ :syslog => false }}
           it { is_expected.to contain_class('pki') }
           it { is_expected.to create_pki__copy('openldap') }
           it { is_expected.to create_file('/etc/pki/simp_apps/openldap/x509')}
           it { is_expected.to create_file('/etc/openldap/slapd.conf').with({
-              :notify => 'Class[Openldap::Server::Service]',
+              :notify => 'Class[Simp_openldap::Server::Service]',
               :content => /TLSCertificateFile/
             })
           }
@@ -76,7 +76,7 @@ describe 'openldap::server::conf' do
 
         context 'force_log_quick_kill' do
           let(:pre_condition) {
-            %( class { "::openldap": base_dn => "dc=host,dc=net" })
+            %( class { "::simp_openldap": base_dn => "dc=host,dc=net" })
           }
 
           let(:params){{ :force_log_quick_kill => true }}
@@ -87,7 +87,7 @@ describe 'openldap::server::conf' do
         context 'enable_iptables' do
           # Testing this by setting the global override
           let(:pre_condition) {
-            %( class { "::openldap": base_dn => "dc=host,dc=net" })
+            %( class { "::simp_openldap": base_dn => "dc=host,dc=net" })
           }
           let(:params){{
             :firewall => true
@@ -100,7 +100,7 @@ describe 'openldap::server::conf' do
         context 'do_not_use_iptables' do
           # Testing this by setting the global override
           let(:pre_condition) {
-            %( class { "::openldap": base_dn => "dc=host,dc=net" })
+            %( class { "::simp_openldap": base_dn => "dc=host,dc=net" })
           }
 
           let(:params){{
@@ -112,7 +112,7 @@ describe 'openldap::server::conf' do
 
         context 'use_iptables_no_listen_ldaps' do
           let(:pre_condition) {
-            %( class { "::openldap": base_dn => "dc=host,dc=net" })
+            %( class { "::simp_openldap": base_dn => "dc=host,dc=net" })
           }
           let(:params){{
             :listen_ldaps => false,
@@ -126,7 +126,7 @@ describe 'openldap::server::conf' do
 
         context 'use_iptables_no_listen_ldap_or_ldaps' do
           let(:pre_condition) {
-            %( class { "::openldap": base_dn => "dc=host,dc=net" })
+            %( class { "::simp_openldap": base_dn => "dc=host,dc=net" })
           }
           let(:params){{
             :listen_ldap  => false,
@@ -141,7 +141,7 @@ describe 'openldap::server::conf' do
 
         context 'audit_transactions' do
           let(:pre_condition) {
-            %( class { "::openldap": base_dn => "dc=host,dc=net" })
+            %( class { "::simp_openldap": base_dn => "dc=host,dc=net" })
           }
           let(:params){{
             :auditlog          => '/var/log/ldap_audit.log',
@@ -162,14 +162,14 @@ describe 'openldap::server::conf' do
               :rotate        => params[:auditlog_preserve]
             })
           }
-          it { is_expected.to create_openldap__server__dynamic_include('auditlog').with_content(/auditlog #{params[:auditlog]}/) }
+          it { is_expected.to create_simp_openldap__server__dynamic_include('auditlog').with_content(/auditlog #{params[:auditlog]}/) }
           it { is_expected.to create_rsyslog__rule__data_source('openldap_audit').with_rule(/File="#{params[:auditlog]}"/) }
           it { is_expected.to create_rsyslog__rule__drop('1_drop_openldap_passwords').with_rule(/contains\s+'Password::\s+'/) }
         end
 
         context 'audit_transactions_no_audit_to_syslog' do
           let(:pre_condition) {
-            %( class { "::openldap": base_dn => "dc=host,dc=net" })
+            %( class { "::simp_openldap": base_dn => "dc=host,dc=net" })
           }
           let(:params){{
             :auditlog          => '/var/log/ldap_audit.log',
@@ -190,14 +190,14 @@ describe 'openldap::server::conf' do
               :rotate        => params[:auditlog_preserve]
             })
           }
-          it { is_expected.to create_openldap__server__dynamic_include('auditlog').with_content(/auditlog #{params[:auditlog]}/) }
+          it { is_expected.to create_simp_openldap__server__dynamic_include('auditlog').with_content(/auditlog #{params[:auditlog]}/) }
           it { is_expected.to_not create_rsyslog__add_conf('openldap_audit') }
           it { is_expected.to_not create_rsyslog__rule__drop('1_drop_openldap_passwords') }
         end
 
         context 'logging_enabled' do
           let(:pre_condition) {
-            %( class { "::openldap": base_dn => "dc=host,dc=net" })
+            %( class { "::simp_openldap": base_dn => "dc=host,dc=net" })
           }
           let(:params){{
             :syslog      => true,
@@ -218,7 +218,7 @@ describe 'openldap::server::conf' do
 
         context 'logging_disabled' do
           let(:pre_condition) {
-            %( class { "::openldap": base_dn => "dc=host,dc=net" })
+            %( class { "::simp_openldap": base_dn => "dc=host,dc=net" })
           }
 
           let(:params){{
@@ -245,7 +245,7 @@ describe 'openldap::server::conf' do
 
         context 'threads_is_user_overridden' do
           let(:pre_condition) {
-            %( class { "::openldap": base_dn => "dc=host,dc=net" })
+            %( class { "::simp_openldap": base_dn => "dc=host,dc=net" })
           }
           let(:params){{ :threads => 20 }}
 

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'openldap::server' do
+describe 'simp_openldap::server' do
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
       context "on #{os}" do
@@ -12,8 +12,8 @@ describe 'openldap::server' do
           facts
         end
 
-        it { is_expected.to create_class('openldap') }
-        it { is_expected.to create_class('openldap::server::conf') }
+        it { is_expected.to create_class('simp_openldap') }
+        it { is_expected.to create_class('simp_openldap::server::conf') }
 
         it { is_expected.to compile.with_all_deps }
         it {
@@ -40,7 +40,7 @@ describe 'openldap::server' do
           '/var/log/slapd.log'
         ].each do |file|
           it {
-            is_expected.to create_file(file).that_requires("Class[Openldap::Server::Install]")
+            is_expected.to create_file(file).that_requires("Class[Simp_openldap::Server::Install]")
           }
         end
 
@@ -56,32 +56,32 @@ describe 'openldap::server' do
           })
         }
 
-        it { is_expected.to create_group('ldap').that_requires("Class[Openldap::Server::Install]") }
+        it { is_expected.to create_group('ldap').that_requires("Class[Simp_openldap::Server::Install]") }
 
         it { is_expected.to create_package('openldap') }
         it { is_expected.to create_package("openldap-servers.#{facts[:hardwaremodel]}") }
 
         it { is_expected.to create_user('ldap').with({
-            :require  => "Class[Openldap::Server::Install]",
-            :notify   => 'Class[Openldap::Server::Service]'
+            :require  => "Class[Simp_openldap::Server::Install]",
+            :notify   => 'Class[Simp_openldap::Server::Service]'
           })
         }
 
-        it { is_expected.to create_class('openldap::slapo::syncprov') }
-        it { is_expected.to create_class('openldap::slapo::ppolicy') }
+        it { is_expected.to create_class('simp_openldap::slapo::syncprov') }
+        it { is_expected.to create_class('simp_openldap::slapo::ppolicy') }
         it { is_expected.to_not create_tcpwrappers__allow('slapd').with_pattern('ALL') }
         it { is_expected.to create_file('/etc/openldap/schema') }
 
         context 'no_sync' do
           let(:params){{ :allow_sync => false }}
 
-          it { is_expected.to_not create_class('openldap::slapo::syncprov') }
+          it { is_expected.to_not create_class('simp_openldap::slapo::syncprov') }
         end
 
         context 'no_ppolicy' do
           let(:params){{ :use_ppolicy => false }}
 
-          it { is_expected.to_not create_class('openldap::slapo::ppolicy') }
+          it { is_expected.to_not create_class('simp_openldap::slapo::ppolicy') }
         end
 
         context 'no_tcpwrappers' do

--- a/spec/classes/slapo/lastbind_spec.rb
+++ b/spec/classes/slapo/lastbind_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'openldap::slapo::lastbind' do
+describe 'simp_openldap::slapo::lastbind' do
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
       context "on #{os}" do
@@ -18,7 +18,7 @@ describe 'openldap::slapo::lastbind' do
           "lastbind-precision #{params[:lastbind_precision]}\n"
         )}
 
-        it { is_expected.to create_openldap__server__dynamic_include('lastbind').that_requires(
+        it { is_expected.to create_simp_openldap__server__dynamic_include('lastbind').that_requires(
           'Package[simp-lastbind]'
         )}
 

--- a/spec/classes/slapo/ppolicy_spec.rb
+++ b/spec/classes/slapo/ppolicy_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'openldap::slapo::ppolicy' do
+describe 'simp_openldap::slapo::ppolicy' do
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
       context "on #{os}" do
@@ -19,7 +19,7 @@ describe 'openldap::slapo::ppolicy' do
 
         it { is_expected.to create_package('simp-ppolicy-check-password') }
 
-        it { is_expected.to create_openldap__server__dynamic_include('ppolicy').with_content(
+        it { is_expected.to create_simp_openldap__server__dynamic_include('ppolicy').with_content(
           /ppolicy_default\s+"cn=default,ou=pwpolicies,#{params[:suffix]}"/
         )}
 

--- a/spec/classes/slapo/syncprov_spec.rb
+++ b/spec/classes/slapo/syncprov_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'openldap::slapo::syncprov' do
+describe 'simp_openldap::slapo::syncprov' do
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
       context "on #{os}" do
@@ -12,11 +12,11 @@ describe 'openldap::slapo::syncprov' do
           facts
         end
 
-        it { is_expected.to create_openldap__server__dynamic_include('syncprov').with_content(
+        it { is_expected.to create_simp_openldap__server__dynamic_include('syncprov').with_content(
           /syncprov-nopresent FALSE/
         )}
 
-        it { is_expected.to create_openldap__server__limits('Allow Sync User Unlimited').with_limits([
+        it { is_expected.to create_simp_openldap__server__limits('Allow Sync User Unlimited').with_limits([
             'size.soft=unlimited',
             'size.hard=unlimited',
             'time.soft=unlimited',
@@ -29,7 +29,7 @@ describe 'openldap::slapo::syncprov' do
 
           it do
             expect {
-              is_expected.to create_openldap__server__dynamic_include('syncprov').with_content(
+              is_expected.to create_simp_openldap__server__dynamic_include('syncprov').with_content(
                 /syncprov-checkpoint #{params[:checkpoint]}/
               )
             }.to_not raise_error

--- a/spec/defines/server/access_spec.rb
+++ b/spec/defines/server/access_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
-describe 'openldap::server::access' do
+describe 'simp_openldap::server::access' do
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
       context "on #{os}" do
         let(:pre_condition) {
-          'class { "openldap": is_server => true }'
+          'class { "simp_openldap": is_server => true }'
         }
 
         let(:facts) do

--- a/spec/defines/server/dynamic_include_spec.rb
+++ b/spec/defines/server/dynamic_include_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
-describe 'openldap::server::dynamic_include' do
+describe 'simp_openldap::server::dynamic_include' do
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
       context "on #{os}" do
         let(:pre_condition) {
-          'class { "openldap": is_server => true }'
+          'class { "simp_openldap": is_server => true }'
         }
 
         let(:facts) do

--- a/spec/defines/server/limits_spec.rb
+++ b/spec/defines/server/limits_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
-describe 'openldap::server::limits' do
+describe 'simp_openldap::server::limits' do
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
       context "on #{os}" do
         let(:pre_condition) {
-          'class { "openldap": is_server => true }'
+          'class { "simp_openldap": is_server => true }'
         }
 
         let(:facts) do
@@ -25,7 +25,7 @@ describe 'openldap::server::limits' do
 
         it { is_expected.to compile.with_all_deps }
 
-        it { is_expected.to create_openldap__server__dynamic_include("limit_#{title}").with_content(
+        it { is_expected.to create_simp_openldap__server__dynamic_include("limit_#{title}").with_content(
           /limits #{params[:who]} #{params[:limits].join(' ')}/
         )}
       end

--- a/spec/defines/server/syncrepl_spec.rb
+++ b/spec/defines/server/syncrepl_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
-describe 'openldap::server::syncrepl' do
+describe 'simp_openldap::server::syncrepl' do
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
       context "on #{os}" do
         let(:pre_condition) {
-          'class { "openldap": is_server => true }'
+          'class { "simp_openldap": is_server => true }'
         }
 
         let(:facts) do
@@ -23,10 +23,10 @@ describe 'openldap::server::syncrepl' do
         it { is_expected.to compile.with_all_deps }
 
         it {
-          is_expected.to create_openldap__server__dynamic_include('syncrepl').with_content(
+          is_expected.to create_simp_openldap__server__dynamic_include('syncrepl').with_content(
             /syncrepl rid=#{params[:rid]}/
           )
-          is_expected.to create_openldap__server__dynamic_include('syncrepl').with_content(
+          is_expected.to create_simp_openldap__server__dynamic_include('syncrepl').with_content(
             /retry="#{params[:syncrepl_retry]}"/
           )
         }

--- a/types/loglevel.pp
+++ b/types/loglevel.pp
@@ -1,5 +1,5 @@
 # OpenLDAP Log Levels
-type Openldap::LogLevel = Variant[
+type Simp_Openldap::LogLevel = Variant[
   Integer[-1,65535],
   Enum[
   'any',

--- a/types/slapdconf/disallow.pp
+++ b/types/slapdconf/disallow.pp
@@ -1,5 +1,5 @@
 # OpenLDAP slapd.conf disallow
-type Openldap::SlapdConf::Disallow = Enum[
+type Simp_Openldap::SlapdConf::Disallow = Enum[
   'bind_anon',
   'bind_simple',
   'tls_2_anon',


### PR DESCRIPTION
Our 'openldap' module has been renamed to 'simp_openldap' so that we
can, in the future, migrate to an alternate core openldap component
module.

SIMP-2427 #close