### PR TITLE
(SIMP-2711) Fix spec tests

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,8 @@
     "simp",
     "openldap",
     "pki",
-    "tls"
+    "tls",
+    "ldap"
   ],
   "dependencies": [
     {
@@ -74,11 +75,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": "4.x"
-    },
-    {
-      "name": "pe",
-      "version_requirement": ">= 2016.2.0"
+      "version_requirement": "4.6"
     }
   ],
   "data_provider": "hiera"

--- a/metadata.json
+++ b/metadata.json
@@ -75,7 +75,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.6"
+      "version_requirement": ">= 4.6.0 < 5.0.0"
     }
   ],
   "data_provider": "hiera"

--- a/metadata.json
+++ b/metadata.json
@@ -75,7 +75,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": "4.6"
+      "version_requirement": ">= 4.6"
     }
   ],
   "data_provider": "hiera"

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 ldap_conf_content = {
   :default =>
     "URI                 ldap://server1.bar.baz ldap://server2.bar.baz\n" +
-    "BASE                ou=foo,dc=bar,dc=baz\n" +
-    "BINDDN              cn=hostAuth,ou=Hosts,ou=foo,dc=bar,dc=baz\n" +
+    "BASE                dc=bar,dc=baz\n" +
+    "BINDDN              cn=hostAuth,ou=Hosts,dc=bar,dc=baz\n" +
     "REFERRALS           on\n" +
     "SIZELIMIT           0\n" +
     "TIMELIMIT           15\n" +
@@ -16,8 +16,8 @@ ldap_conf_content = {
 
   :with_crlfile =>
     "URI                 ldap://server1.bar.baz ldap://server2.bar.baz\n" +
-    "BASE                ou=foo,dc=bar,dc=baz\n" +
-    "BINDDN              cn=hostAuth,ou=Hosts,ou=foo,dc=bar,dc=baz\n" +
+    "BASE                dc=bar,dc=baz\n" +
+    "BINDDN              cn=hostAuth,ou=Hosts,dc=bar,dc=baz\n" +
     "REFERRALS           on\n" +
     "SIZELIMIT           0\n" +
     "TIMELIMIT           15\n" +
@@ -30,8 +30,8 @@ ldap_conf_content = {
 
   :without_tls =>
     "URI                 ldap://server1.bar.baz ldap://server2.bar.baz\n" +
-    "BASE                ou=foo,dc=bar,dc=baz\n" +
-    "BINDDN              cn=hostAuth,ou=Hosts,ou=foo,dc=bar,dc=baz\n" +
+    "BASE                dc=bar,dc=baz\n" +
+    "BINDDN              cn=hostAuth,ou=Hosts,dc=bar,dc=baz\n" +
     "REFERRALS           on\n" +
     "SIZELIMIT           0\n" +
     "TIMELIMIT           15\n" +
@@ -76,11 +76,12 @@ describe 'simp_openldap::client' do
     on_supported_os.each do |os, facts|
       context "on #{os}" do
         let(:facts) {
+          facts[:fqdn]         = 'myserver.test.local'
+          facts[:domain]       = 'bar.baz'
           facts[:server_facts] = {
             :servername => facts[:fqdn],
             :serverip   => facts[:ipaddress]
           }
-          facts[:fqdn] = 'myserver.test.local'
           facts
         }
 

--- a/spec/fixtures/hieradata/default.yaml
+++ b/spec/fixtures/hieradata/default.yaml
@@ -3,12 +3,12 @@ simp_options::trusted_nets :
   - 1.2.3.4
   - 5.6.7.8
 simp_options::puppet::server : "puppet.server.com"
-simp_options::ldap::base_dn : "ou=foo,dc=bar,dc=baz"
+simp_options::ldap::base_dn : "dc=bar,dc=baz"
 simp_options::ldap::bind_pw : "s00per sekr3t!"
 simp_options::ldap::bind_hash : '{SSHA}foobarbaz!!!!'
-simp_options::ldap::sync_dn : "cn=sync,ou=Hosts,%{hiera('ldap::base_dn')}"
+simp_options::ldap::sync_dn : "cn=sync,ou=Hosts,%{hiera('simp_options::ldap::base_dn')}"
 simp_options::ldap::sync_hash : '{SSHA}foobarbaz!!!!'
-simp_options::ldap::root_dn : "cn=LDAPAdmin,ou=People,%{hiera('ldap::base_dn')}"
+simp_options::ldap::root_dn : "cn=LDAPAdmin,ou=People,%{hiera('simp_options::ldap::base_dn')}"
 simp_options::ldap::root_hash : '{SSHA}foobarbaz!!!!'
 simp_options::syslog : true
 simp_options::iptables : true


### PR DESCRIPTION
This commit also updates the requirements in the metadata.json to
require Puppet >= 4.6

SIMP-2711 #close