### PR TITLE
(SIMP-2816) Fix conn_max_pending_auth parameter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed Mar 08 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.1-0
+- Corrected the openldap::server::conf::conn_max_pending_auth to be set to 1000
+  instead of 100
+
 * Wed Jan 25 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.0-0
 - Rename from 'openldap' to 'simp_openldap' so that we can migrate to an
   alternate backend in the future

--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -245,7 +245,7 @@ class simp_openldap::server::conf (
   Simplib::Netlist                                    $trusted_nets               = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1'] }),
   Optional[Integer[1]]                                $concurrency                = undef,
   Integer[1]                                          $conn_max_pending           = 100,
-  Integer[1]                                          $conn_max_pending_auth      = 100,
+  Integer[1]                                          $conn_max_pending_auth      = 1000,
   Array[String[1]]                                    $default_schemas            = [ 'openssh-lpk', 'freeradius', 'autofs' ],
   Optional[String[1]]                                 $default_searchbase         = undef,
   Array[Simp_Openldap::SlapdConf::Disallow]                $disallow                   = ['bind_anon','tls_2_anon'],

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_openldap",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "author": "SIMP Team",
   "summary": "Manages OpenLDAP and related security bindings",
   "license": "Apache-2.0",


### PR DESCRIPTION
The default should be 1000 instead of 100 per the man page

SIMP-2816 #close