### PR TITLE
(SIMP-2833) Changed server::conf::rootpw default

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Mar 13 2017 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.1-0
+- server::conf::rootpw default no longer references simp_options,
+  it defaults to undef.
+
 * Wed Mar 08 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.1-0
 - Corrected the openldap::server::conf::conn_max_pending_auth to be set to 1000
   instead of 100

--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -218,7 +218,7 @@
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class simp_openldap::server::conf (
-  Optional[String[1]]                                 $rootpw                     = simplib::lookup('simp_options::ldap::root_hash', { 'default_value' => undef }),
+  Optional[String[1]]                                 $rootpw                     = undef,
   Optional[String[1]]                                 $syncpw                     = simplib::lookup('simp_options::ldap::sync_hash', { 'default_value' => undef }),
   Optional[String[1]]                                 $bindpw                     = simplib::lookup('simp_options::ldap::bind_hash', { 'default_value' => undef }),
   String[1]                                           $syncdn                     = simplib::lookup('simp_options::ldap::sync_dn', { 'default_value' => "LDAPSync,ou=People,${::simp_openldap::base_dn}" }),

--- a/spec/acceptance/suites/default/templates/server_hieradata.yaml.erb
+++ b/spec/acceptance/suites/default/templates/server_hieradata.yaml.erb
@@ -20,7 +20,6 @@ simp_options::ldap::sync_dn: 'cn=LDAPSync,ou=Hosts,<%= base_dn %>'
 simp_options::ldap::sync_pw: 'foobarbaz'
 simp_options::ldap::sync_hash: '{SSHA}BNPDR0qqE6HyLTSlg13T0e/+yZnSgYQz'
 simp_options::ldap::root_dn: 'cn=LDAPAdmin,ou=People,<%= base_dn %>'
-simp_options::ldap::root_hash: '{SSHA}BNPDR0qqE6HyLTSlg13T0e/+yZnSgYQz'
 simp_options::ldap::master: 'ldap://<%= server_fqdn %>'
 # suP3rP@ssw0r!
-simp_options::ldap::root_hash: "{SSHA}ZcqPNbcqQhDNF5jYTLGl+KAGcrHNW9oo"
+simp_openldap::server::conf::rootpw: "{SSHA}ZcqPNbcqQhDNF5jYTLGl+KAGcrHNW9oo"

--- a/spec/acceptance/suites/default/templates/server_hieradata_tls.yaml.erb
+++ b/spec/acceptance/suites/default/templates/server_hieradata_tls.yaml.erb
@@ -21,7 +21,6 @@ simp_options::ldap::sync_dn: 'cn=LDAPSync,ou=Hosts,<%= base_dn %>'
 simp_options::ldap::sync_pw: 'foobarbaz'
 simp_options::ldap::sync_hash: '{SSHA}BNPDR0qqE6HyLTSlg13T0e/+yZnSgYQz'
 simp_options::ldap::root_dn: 'cn=LDAPAdmin,ou=People,<%= base_dn %>'
-simp_options::ldap::root_hash: '{SSHA}BNPDR0qqE6HyLTSlg13T0e/+yZnSgYQz'
 simp_options::ldap::master: 'ldap://<%= server_fqdn %>'
 # suP3rP@ssw0r!
-simp_options::ldap::root_hash: "{SSHA}ZcqPNbcqQhDNF5jYTLGl+KAGcrHNW9oo"
+simp_openldap::server::conf::rootpw: "{SSHA}ZcqPNbcqQhDNF5jYTLGl+KAGcrHNW9oo"

--- a/spec/fixtures/hieradata/default.yaml
+++ b/spec/fixtures/hieradata/default.yaml
@@ -9,13 +9,13 @@ simp_options::ldap::bind_hash : '{SSHA}foobarbaz!!!!'
 simp_options::ldap::sync_dn : "cn=sync,ou=Hosts,%{hiera('simp_options::ldap::base_dn')}"
 simp_options::ldap::sync_hash : '{SSHA}foobarbaz!!!!'
 simp_options::ldap::root_dn : "cn=LDAPAdmin,ou=People,%{hiera('simp_options::ldap::base_dn')}"
-simp_options::ldap::root_hash : '{SSHA}foobarbaz!!!!'
 simp_options::syslog : true
 simp_options::iptables : true
 simp_options::ldap::uri :
   - "ldap://server1.bar.baz"
   - "ldap://server2.bar.baz"
 simp_options::ldap::master : "ldap://server1.bar.baz"
+simp_openldap::server::conf::rootpw: '{SSHA}foobarbaz!!!!'
 simp::rsync_server : 'rsync.bar.baz'
 rsync::timeout : '1'
 sssd::domains :


### PR DESCRIPTION
- server::conf::rootpw default no longer references simp_options,
  it defaults to undef.

SIMP-2833 #close