### PR TITLE
(SIMP-2992) Work around for broken LDAP libs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
+* Fri Apr 07 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.2-0
+- Ensure that 128-bit ciphers are not present in ldap.conf for EL6 systems
+
 * Mon Mar 13 2017 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.1-0
 - server::conf::rootpw default no longer references simp_options,
-  it defaults to undef.
+  it defaults to undef
 
 * Wed Mar 08 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.1-0
 - Removed the 'acl' log level from the default list since it was causing low

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -29,23 +29,48 @@
 # @param app_pki_crl
 #   Path to the CRL file.
 #
+# @param strip_128_bit_ciphers
+#   On EL6 systems, all 128-bit ciphers will be removed from ``tls_cipher_suite``
+#
+#   * This is due to a bug in the LDAP client libraries that does not appear to
+#     honor the order of the SSL ciphers and will attempt to connect with
+#     128-bit ciphers and not use stronger ciphers when those are present. This
+#     breaks connections to securely configured LDAP servers.
+#
 class simp_openldap::client (
-  Array[Simplib::URI]                          $uri                 = $::simp_openldap::_ldap_uri,
-  Optional[String]                             $base_dn             = $::simp_openldap::base_dn,
-  String[1]                                    $bind_dn             = $::simp_openldap::bind_dn,
-  Enum['on','off']                             $referrals           = 'on',
-  Integer                                      $sizelimit           = 0,
-  Integer                                      $timelimit           = 15,
-  Variant[Enum['simp'],Boolean]                $use_tls             = $::simp_openldap::pki,
-  Stdlib::Absolutepath                         $app_pki_ca_dir      = $::simp_openldap::app_pki_ca_dir,
-  Stdlib::Absolutepath                         $app_pki_cert        = $::simp_openldap::app_pki_cert,
-  Stdlib::Absolutepath                         $app_pki_key         = $::simp_openldap::app_pki_key,
-  Optional[Stdlib::Absolutepath]               $app_pki_crl         = $::simp_openldap::app_pki_crl,
-  Array[String[1]]                             $tls_cipher_suite    = simplib::lookup('simp_options::openssl::cipher_suite', { 'default_value' => ['DEFAULT','!MEDIUM'] }),
-  Enum['none','peer','all']                    $tls_crlcheck        = 'none',
-  Enum['never','searching','finding','always'] $deref               = 'never',
-  Enum['never','allow','try','demand','hard']  $tls_reqcert         = 'allow'
+  Array[Simplib::URI]                          $uri                   = $::simp_openldap::_ldap_uri,
+  Optional[String]                             $base_dn               = $::simp_openldap::base_dn,
+  String[1]                                    $bind_dn               = $::simp_openldap::bind_dn,
+  Enum['on','off']                             $referrals             = 'on',
+  Integer                                      $sizelimit             = 0,
+  Integer                                      $timelimit             = 15,
+  Variant[Enum['simp'],Boolean]                $use_tls               = $::simp_openldap::pki,
+  Stdlib::Absolutepath                         $app_pki_ca_dir        = $::simp_openldap::app_pki_ca_dir,
+  Stdlib::Absolutepath                         $app_pki_cert          = $::simp_openldap::app_pki_cert,
+  Stdlib::Absolutepath                         $app_pki_key           = $::simp_openldap::app_pki_key,
+  Optional[Stdlib::Absolutepath]               $app_pki_crl           = $::simp_openldap::app_pki_crl,
+  Boolean                                      $strip_128_bit_ciphers = true,
+  Array[String[1]]                             $tls_cipher_suite      = simplib::lookup('simp_options::openssl::cipher_suite', { 'default_value' => ['DEFAULT','!MEDIUM'] }),
+  Enum['none','peer','all']                    $tls_crlcheck          = 'none',
+  Enum['never','searching','finding','always'] $deref                 = 'never',
+  Enum['never','allow','try','demand','hard']  $tls_reqcert           = 'allow'
 ) inherits ::simp_openldap {
+
+  if $strip_128_bit_ciphers {
+    # This is here due to a bug in the LDAP client library on EL6 that will set
+    # the SSF to 128 when connecting over StartTLS if there are *any* 128-bit
+    # ciphers in the list.
+    if $facts['os']['name'] in ['RedHat','CentOS'] and (versioncmp($facts['os']['release']['major'],'7') < 0) {
+      $_tmp_suite = flatten($tls_cipher_suite.map |$cipher| { split($cipher,':') })
+      $_tls_cipher_suite = $_tmp_suite.filter |$cipher| { $cipher !~ Pattern[/128/] }
+    }
+    else {
+      $_tls_cipher_suite = $tls_cipher_suite
+    }
+  }
+  else {
+    $_tls_cipher_suite = $tls_cipher_suite
+  }
 
   file { '/etc/openldap/ldap.conf':
     owner   => 'root',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_openldap",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "author": "SIMP Team",
   "summary": "Manages OpenLDAP and related security bindings",
   "license": "Apache-2.0",

--- a/templates/etc/openldap/ldap.conf.erb
+++ b/templates/etc/openldap/ldap.conf.erb
@@ -7,7 +7,7 @@ TIMELIMIT           <%= @timelimit %>
 DEREF               <%= @deref %>
 <% if @use_tls -%>
 TLS_CACERTDIR       <%= @app_pki_ca_dir %>
-TLS_CIPHER_SUITE    <%= Array(@tls_cipher_suite).join(':') %>
+TLS_CIPHER_SUITE    <%= Array(@_tls_cipher_suite).join(':') %>
 TLS_REQCERT         <%= @tls_reqcert %>
 TLS_CRLCHECK        <%= @tls_crlcheck %>
 <%   if @app_pki_crl -%>


### PR DESCRIPTION
The client LDAP libraries are broken in EL6 such that, if any 128 bit
ciphers are present in the cipher string, it will fall back to SSF=128
for connecting to an LDAP server.

This is unacceptable to the SIMP default configuration (SSF=256).

Also, fixed a bug in a template with regards to variables with prefaced
underscores.

SIMP-2992 #close Update for OpenLDAP Client