### PR TITLE
(SIMP-2994) Change case of DC= in ldap dn

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,59 @@
+# 
+---
+puppet-syntax:
+  stage: test
+  tags:
+    - docker
+  image: ruby:2.1
+  script:
+    - bundle install
+    - bundle exec rake syntax
+puppet-lint:
+  stage: test
+  tags:
+    - docker
+  image: ruby:2.1
+  script:
+    - bundle install
+    - bundle exec rake lint
+puppet-metadata:
+  stage: test
+  tags:
+    - docker
+  image: ruby:2.1
+  script:
+    - bundle install
+    - bundle exec rake metadata
+unit-test-ruby-2.1:
+  stage: test
+  tags:
+    - docker
+  image: ruby:2.1
+  script:
+    - bundle install
+    - bundle exec rake spec
+unit-test-ruby-2.2:
+  stage: test
+  tags:
+    - docker
+  image: ruby:2.2
+  allow_failure: true
+  script:
+    - bundle install
+    - bundle exec rake spec
+unit-test-ruby-2.3:
+  stage: test
+  tags:
+    - docker
+  image: ruby:2.3
+  allow_failure: true
+  script:
+    - bundle install
+    - bundle exec rake spec
+acceptance-test:
+  stage: test
+  tags:
+    - beaker
+  script:
+    - bundle install --no-binstubs --path=vendor
+    - bundle exec rake acceptance

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -4,7 +4,7 @@ ldap_conf_content = {
   :default =>
     "URI                 ldap://server1.bar.baz ldap://server2.bar.baz\n" +
     "BASE                dc=bar,dc=baz\n" +
-    "BINDDN              cn=hostAuth,ou=Hosts,dc=bar,dc=baz\n" +
+    "BINDDN              cn=hostAuth,ou=Hosts,DC=bar,DC=baz\n" +
     "REFERRALS           on\n" +
     "SIZELIMIT           0\n" +
     "TIMELIMIT           15\n" +
@@ -17,7 +17,7 @@ ldap_conf_content = {
   :with_crlfile =>
     "URI                 ldap://server1.bar.baz ldap://server2.bar.baz\n" +
     "BASE                dc=bar,dc=baz\n" +
-    "BINDDN              cn=hostAuth,ou=Hosts,dc=bar,dc=baz\n" +
+    "BINDDN              cn=hostAuth,ou=Hosts,DC=bar,DC=baz\n" +
     "REFERRALS           on\n" +
     "SIZELIMIT           0\n" +
     "TIMELIMIT           15\n" +
@@ -31,7 +31,7 @@ ldap_conf_content = {
   :without_tls =>
     "URI                 ldap://server1.bar.baz ldap://server2.bar.baz\n" +
     "BASE                dc=bar,dc=baz\n" +
-    "BINDDN              cn=hostAuth,ou=Hosts,dc=bar,dc=baz\n" +
+    "BINDDN              cn=hostAuth,ou=Hosts,DC=bar,DC=baz\n" +
     "REFERRALS           on\n" +
     "SIZELIMIT           0\n" +
     "TIMELIMIT           15\n" +


### PR DESCRIPTION
* the spec tests for simp_openldap will break if the change to
  simplib::ldap::domain_to_dn in SIMP-2994 are merged in. This fixes
  those tests

SIMP-2994 #comment