### PR TITLE
(SIMP-3152) Added a test to check published RPM

### DIFF
--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -5,7 +5,7 @@ HOSTS:
       - server
     yum_repos:
       simp:
-        baseurl: https://packagecloud.io/simp-project/6_X_Alpha_Dependencies/el/7/$basearch
+        baseurl: https://packagecloud.io/simp-project/6_X_Dependencies/el/7/$basearch
         gpgkeys:
           - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
     platform:   el-7-x86_64
@@ -16,7 +16,7 @@ HOSTS:
       - server
     yum_repos:
       simp:
-        baseurl: https://packagecloud.io/simp-project/6_X_Alpha_Dependencies/el/7/$basearch
+        baseurl: https://packagecloud.io/simp-project/6_X_Dependencies/el/6/$basearch
         gpgkeys:
           - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
     platform:   el-6-x86_64

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -4,21 +4,6 @@ require 'erb'
 test_name 'simp_openldap class'
 
 describe 'simp_openldap class' do
-  before(:context) do
-    hosts.each do |host|
-      interfaces = fact_on(host, 'interfaces').strip.split(',')
-      interfaces.delete_if do |x|
-        x =~ /^lo/
-      end
-
-      interfaces.each do |iface|
-        if fact_on(host, "ipaddress_#{iface}").strip.empty?
-          on(host, "ifup #{iface}", :accept_all_exit_codes => true)
-        end
-      end
-    end
-  end
-
   servers = hosts_with_role(hosts, 'server')
   # slaves = hosts_with_role(hosts, 'slave')
 

--- a/spec/acceptance/suites/default/01_simp_ppolicy_check_password_spec.rb
+++ b/spec/acceptance/suites/default/01_simp_ppolicy_check_password_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper_acceptance'
+require 'erb'
+
+test_name 'simp-ppolicy-check-password update test'
+
+describe 'simp-ppolicy-check-password update' do
+  servers = hosts_with_role(hosts, 'server')
+
+  servers.each do |server|
+    context "on server #{server}" do
+      let(:slapd_svc){
+        require 'yaml'
+
+        svc_name = 'slapd'
+
+        # Some call it 'slapd', others 'ldap'
+        svcs = YAML.load(on(server, 'puppet resource service --to_yaml').stdout)['service'].keys.map{|x| x.chomp('.service')}
+
+        if svcs.include?('ldap')
+          svc_name = 'ldap'
+        end
+
+        svc_name
+      }
+
+      let(:server_fqdn) { fact_on(server, 'fqdn') }
+      let(:base_dn) { fact_on(server, 'domain').split('.').map{ |d| "dc=#{d}" }.join(',') }
+
+      context 'on the clean server' do
+        it 'should be running openldap' do
+          on(server, "puppet resource service #{slapd_svc} ensure=running")
+        end
+
+        it 'should be using the latest simp-ppolicy-check-password package' do
+          on(server, 'puppet resource package simp-ppolicy-check-password ensure=latest')
+          on(server, "puppet resource service #{slapd_svc} ensure=stopped")
+          on(server, "puppet resource service #{slapd_svc} ensure=running")
+        end
+
+        it 'should have a test user from a previous test' do
+          result = on(server, "ldapsearch -Z -LLL -D cn=LDAPAdmin,ou=People,#{base_dn} -H ldap://#{server_fqdn} -w suP3rP@ssw0r! -x cn=test.user")
+          expect(result.stdout).to include("dn: cn=test.user,ou=Group,#{base_dn}")
+        end
+      end
+
+      context 'when updating openldap' do
+        it 'should update openldap' do
+          on(server, 'yum update -y openldap*')
+          server.reboot
+        end
+
+        it 'should be running openldap' do
+          on(server, "puppet resource service #{slapd_svc} ensure=running")
+        end
+
+        it 'should be able to access the test user' do
+          result = on(server, "ldapsearch -Z -LLL -D cn=LDAPAdmin,ou=People,#{base_dn} -H ldap://#{server_fqdn} -w suP3rP@ssw0r! -x cn=test.user")
+          expect(result.stdout).to include("dn: cn=test.user,ou=Group,#{base_dn}")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We publish a simp-ppolicy-check-password RPM and we need to be sure
that it's still functional as time moves forward.

The basic tests *should* do this, but they don't always update
openldap to the latest version.

SIMP-3152 #close