### PR TITLE
(SIMP-3894) Allow custom GIDs in default.ldif

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Dec 04 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.2.0-0
+- Allow setting the 'users' and 'administrators' GIDs in the default ldif file
+
 * Thu Nov 16 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.1.2-0
 - Fix an incorrect dependency for puppetlabs/concat in the metadata.json
 

--- a/manifests/server/conf/default_ldif.pp
+++ b/manifests/server/conf/default_ldif.pp
@@ -8,7 +8,7 @@
 #
 class simp_openldap::server::conf::default_ldif (
   Integer[1]   $users_group_id                     = 100,
-  Integer[501] $administrators_group_id            = 700,
+  Integer[500] $administrators_group_id            = 700,
   Integer[0]   $ppolicy_pwd_min_age                = 86400,
   Integer[1]   $ppolicy_pwd_max_age                = 15552000,
   Integer[0]   $ppolicy_pwd_in_history             = 24,

--- a/manifests/server/conf/default_ldif.pp
+++ b/manifests/server/conf/default_ldif.pp
@@ -1,26 +1,28 @@
 # **NOTE: THIS IS A [PRIVATE](https://github.com/puppetlabs/puppetlabs-stdlib#assert_private) CLASS**
 #
 # This allows for the modification of the default LDIF entries in
-# /etc/openldap/default.ldif. It will *not* modify any active values in a
+# /etc/openldap/default.ldif. It will **not** modify any active values in a
 # running LDAP server.
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class simp_openldap::server::conf::default_ldif (
-  Integer[0] $ppolicy_pwd_min_age                = 86400,
-  Integer[1] $ppolicy_pwd_max_age                = 15552000,
-  Integer[0] $ppolicy_pwd_in_history             = 24,
-  Integer[0] $ppolicy_pwd_check_quality          = 2,
-  Integer[0] $ppolicy_pwd_min_length             = 14,
-  Integer[0] $ppolicy_pwd_expire_warning         = 1209600,
-  Integer    $ppolicy_pwd_grace_authn_limit      = -1,
-  Boolean    $ppolicy_pwd_lockout                = true,
-  Integer[0] $ppolicy_pwd_lockout_duration       = 900,
-  Integer[0] $ppolicy_pwd_max_failure            = 5,
-  Integer[0] $ppolicy_pwd_failure_count_interval = 900,
-  Boolean    $ppolicy_pwd_must_change            = true,
-  Boolean    $ppolicy_pwd_allow_user_change      = true,
-  Boolean    $ppolicy_pwd_safe_modify            = false
+  Integer[1]   $users_group_id                     = 100,
+  Integer[501] $administrators_group_id            = 700,
+  Integer[0]   $ppolicy_pwd_min_age                = 86400,
+  Integer[1]   $ppolicy_pwd_max_age                = 15552000,
+  Integer[0]   $ppolicy_pwd_in_history             = 24,
+  Integer[0]   $ppolicy_pwd_check_quality          = 2,
+  Integer[0]   $ppolicy_pwd_min_length             = 14,
+  Integer[0]   $ppolicy_pwd_expire_warning         = 1209600,
+  Integer      $ppolicy_pwd_grace_authn_limit      = -1,
+  Boolean      $ppolicy_pwd_lockout                = true,
+  Integer[0]   $ppolicy_pwd_lockout_duration       = 900,
+  Integer[0]   $ppolicy_pwd_max_failure            = 5,
+  Integer[0]   $ppolicy_pwd_failure_count_interval = 900,
+  Boolean      $ppolicy_pwd_must_change            = true,
+  Boolean      $ppolicy_pwd_allow_user_change      = true,
+  Boolean      $ppolicy_pwd_safe_modify            = false
 ) {
 
   assert_private()

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_openldap",
-  "version": "6.1.2",
+  "version": "6.2.0",
   "author": "SIMP Team",
   "summary": "Manages OpenLDAP and related security bindings",
   "license": "Apache-2.0",

--- a/spec/classes/server/conf_spec.rb
+++ b/spec/classes/server/conf_spec.rb
@@ -180,6 +180,12 @@ include /etc/openldap/dynamic_includes
           it { is_expected.to create_file('/etc/openldap/DB_CONFIG').with_content(/set_data_dir/) }
           it { is_expected.to create_file('/etc/openldap/default.ldif').with_content(/dn: DC=host,DC=net/) }
           it { is_expected.to create_file('/etc/openldap/default.ldif').with_content(/pwdCheckModule: .*check_password.so/) }
+
+          # Users
+          it { is_expected.to create_file('/etc/openldap/default.ldif').with_content(/gidNumber: 100/) }
+
+          # Administrators
+          it { is_expected.to create_file('/etc/openldap/default.ldif').with_content(/gidNumber: 700/) }
           it {
             if ['RedHat','CentOS'].include?(facts[:operatingsystem]) and facts[:operatingsystemmajrelease] < "7"
             then

--- a/templates/etc/openldap/default.ldif.erb
+++ b/templates/etc/openldap/default.ldif.erb
@@ -83,13 +83,13 @@ dn: cn=users,ou=Group,<%= @_suffix %>
 objectClass: posixGroup
 objectClass: top
 cn: users
-gidNumber: 100
+gidNumber: <%= @users_group_id %>
 
 dn: cn=administrators,ou=Group,<%= @_suffix %>
 objectClass: posixGroup
 objectClass: top
 cn: administrators
-gidNumber: 700
+gidNumber: <%= @administrators_group_id %>
 
 dn: ou=pwpolicies,<%= @_suffix %>
 ou: pwpolicies


### PR DESCRIPTION
Allow users to set the 'users' and 'administrators' GID values in the
'default.ldif' file.

These were *not* exposed at a higher level to prevent needing to make
breaking changes in the near future and given that none of the other
settings were exposed at that level.

If this is needed, we will need to create another change in the future.

SIMP-4131 #close
SIMP-4132 #close