### PR TITLE
(SIMP-6118)Use namespaced simplib::validate_re_array

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Mar 19 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.3.2-0
+- Use simplib::validate_re_array in lieu of deprecated Puppet 3 validate_re_array
+- Use Puppet Integer() in lieu of simplib's deprecated Puppet 3 to_integer
+
 * Mon Mar 04 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.3.1-0
 - Expanded the upper limit of the concat and stdlib Puppet module versions
 - Updated a URL in the README.md

--- a/manifests/server/syncrepl.pp
+++ b/manifests/server/syncrepl.pp
@@ -6,7 +6,7 @@
 # $name should be the 'rid' of the syncrepl instance and must be between 0 and
 # 1000, non-inclusive.
 #
-# @author Trevor Vaughan <tvaughan@onyxpoint.com>
+# @author https://github.com/simp/pupmod-simp-simp_openldap/graphs/contributors
 #
 define simp_openldap::server::syncrepl (
   String[1]                               $syncrepl_retry = '60 10 600 +',
@@ -35,7 +35,7 @@ define simp_openldap::server::syncrepl (
   Enum['default','accesslog']             $syncdata       = 'default',
   Optional[String[1]]                     $updateref      = undef
 ) {
-  if to_integer($name) !~ Integer[1,999] {
+  if Integer($name) !~ Integer[1,999] {
     fail('$name must be an integer between `1` and `999`')
   }
 
@@ -49,7 +49,7 @@ define simp_openldap::server::syncrepl (
     fail('You must provide a valie for `$provider`')
   }
 
-  validate_re_array(split($syncrepl_retry,'(\d+ \d+)'),'^(\s*(\d+ (\d+|\+)\s*)|\s*)$')
+  simplib::validate_re_array(split($syncrepl_retry,'(\d+ \d+)'),'^(\s*(\d+ (\d+|\+)\s*)|\s*)$')
 
   simp_openldap::server::dynamic_include { 'syncrepl':
     content => template("${module_name}/syncrepl.erb")

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_openldap",
-  "version": "6.3.1",
+  "version": "6.3.2",
   "author": "SIMP Team",
   "summary": "Manages OpenLDAP and related security bindings",
   "license": "Apache-2.0",
@@ -41,7 +41,7 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.2.0 < 4.0.0"
+      "version_requirement": ">= 3.7.0 < 4.0.0"
     },
     {
       "name": "simp/sssd",


### PR DESCRIPTION
- Use simplib::validate_re_array in lieu of deprecated Puppet 3 validate_re_array
- Use Puppet Integer() in lieu of simplib's deprecated Puppet 3 to_integer

SIMP-6118 #close