### PR TITLE
(SIMP-9380) simp_openldap client pki::copy fails

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -83,21 +83,9 @@ class simp_openldap (
   include 'simp_openldap::client'
 
   if $pki {
-    # The 'ldap' group needs to be used for the pki:copy for the LDAP server,
-    # so that its daemon (slapd) can access the certs. If simp_openldap::server
-    # was included in a manifest directly, $is_server may not be true. So, need
-    # to check if the simp_openldap::server resource is available, instead.
-    if defined(Class['simp_openldap::server']) {
-      $_ldap_group = 'ldap'
-    }
-    else {
-      $_ldap_group = 'root'
-    }
-
     pki::copy { 'openldap':
       source => $app_pki_external_source,
-      pki    => $pki,
-      group  => $_ldap_group
+      pki    => $pki
     }
   }
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -248,6 +248,15 @@ class simp_openldap::server (
   contain 'simp_openldap::server::service'
 
   if $simp_openldap::pki {
+
+    # The 'ldap' group needs to be used for the pki:copy for the LDAP server,
+    # so that its daemon (slapd) can access the certs. Because of the way
+    # the module is structured, cannot reliably determine this when the
+    # resource is first declared.
+    Pki::Copy <| title == 'openldap' |> {
+      group => 'ldap'
+    }
+
     Pki::Copy['openldap'] ~> Class['simp_openldap::server::service']
   }
 }


### PR DESCRIPTION
Second attempt at the fix. Although the original fix worked for the
acceptance tests in this module, it did not work in simp-core's
default acceptance test. This means the original solution was
too heavily tied to nondeterministic compiler behavior.

SIMP-9380 #close