### PR TITLE
Add RockyLinux 8 support

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -109,14 +109,16 @@ jobs:
     strategy:
       matrix:
         puppet:
-          - label: 'Puppet 7.x'
-            puppet_version: '~> 7.21.0'
+          - label: 'Puppet 7.x [SIMP 6.6/PE 2021.7]'
+            puppet_version: '~> 7.0'
             ruby_version: '2.7'
+            experimental: false
           - label: 'Puppet 8.x'
             puppet_version: '~> 8.0'
-            ruby_version: '3.2'
+            ruby_version: 3.1
+            experimental: true
     env:
-      PUPPET_VERSION: '${{matrix.puppet.puppet_version}}'
+      PUPPET_VERSION: ${{matrix.puppet.puppet_version}}
     steps:
       - uses: actions/checkout@v3
       - name: 'Install Ruby ${{matrix.puppet.ruby_version}}'
@@ -126,6 +128,7 @@ jobs:
           bundler-cache: true
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
       - run: 'bundle exec rake spec'
+        continue-on-error: ${{matrix.puppet.experimental}}
 
 #  dump_contexts:
 #    name: 'Examine Context contents'

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -9,7 +9,7 @@
 --no-class_inherits_from_params_class-check
 --no-140chars-check
 --no-trailing_comma-check
---no-empty_string_assignment-check
+--no-params-empty-string-assignment-check
 # This is here because the code can't handle lookups in parameters and SIMP
 # modules have a LOT of those
 --no-parameter_order-check

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Jun 12 2023 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.7.0
+- Add RockyLinux 8 support
+
 * Thu Jun 17 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.6.0
 - Removed support for Puppet 5
 - Ensured support for Puppet 7 in requirements and stdlib

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ group :test do
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
   gem 'puppet-strings'
-  gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
   gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.12.1', '< 6']

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -97,7 +97,7 @@ class simp_openldap::client (
     content => template("${module_name}/ldaprc.erb")
   }
 
-  package { "openldap-clients.${facts['hardwaremodel']}":
+  package { "openldap-clients.${facts['os']['hardware']}":
     ensure => $openldap_clients_ensure
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,8 +69,8 @@ class simp_openldap (
   Variant[Boolean, Enum['simp']] $pki                     = simplib::lookup('simp_options::pki', { 'default_value' => false }),
   String                         $app_pki_external_source = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
   Stdlib::Absolutepath           $app_pki_dir             = '/etc/pki/simp_apps/openldap/x509',
-  Stdlib::AbsolutePath           $app_pki_cert            = "${app_pki_dir}/public/${facts['fqdn']}.pub",
-  Stdlib::AbsolutePath           $app_pki_key             = "${app_pki_dir}/private/${facts['fqdn']}.pem",
+  Stdlib::AbsolutePath           $app_pki_cert            = "${app_pki_dir}/public/${facts['networking']['fqdn']}.pub",
+  Stdlib::AbsolutePath           $app_pki_key             = "${app_pki_dir}/private/${facts['networking']['fqdn']}.pem",
   Stdlib::AbsolutePath           $app_pki_ca_dir          = "${app_pki_dir}/cacerts",
   Optional[Stdlib::Absolutepath] $app_pki_crl             = undef,
 ) {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -61,7 +61,7 @@ class simp_openldap::server (
   $_os_name = $facts.dig('os','name')
 
   if versioncmp($_os_version, '7') > 0 {
-    fail("$_os_name version $_os_version is not supported as an LDAP server")
+    fail("${_os_name} version ${_os_version} is not supported as an LDAP server")
   }
 
   contain 'simp_openldap::server::install'

--- a/manifests/server/fix_bad_upgrade.pp
+++ b/manifests/server/fix_bad_upgrade.pp
@@ -19,7 +19,7 @@ class simp_openldap::server::fix_bad_upgrade {
       if [ -f /etc/openldap/slapd.conf.bak ]; then \
         /bin/mv /etc/openldap/slapd.conf.bak /etc/openldap.slapd.conf; \
       fi',
-    require => Package["openldap-servers.${facts['hardwaremodel']}"],
+    require => Package["openldap-servers.${facts['os']['hardware']}"],
     notify  => File['/var/lib/ldap/DB_CONFIG'],
     onlyif  => '/usr/bin/test -d /etc/openldap/slapd.d',
     before  => [

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -12,7 +12,7 @@ class simp_openldap::server::install (
   package { 'openldap':
     ensure => $ensure
   }
-  package { "openldap-servers.${facts['hardwaremodel']}":
+  package { "openldap-servers.${facts['os']['hardware']}":
     ensure => $ensure
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_openldap",
-  "version": "6.6.0",
+  "version": "6.7.0",
   "author": "SIMP Team",
   "summary": "Manages OpenLDAP and related security bindings",
   "license": "Apache-2.0",
@@ -20,7 +20,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 6.6.0 < 8.0.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     },
     {
       "name": "simp/iptables",
@@ -64,6 +64,12 @@
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "7"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
+        "8"
       ]
     }
   ],

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -6,6 +6,7 @@ describe 'simp_openldap::client' do
       let(:facts) {
         facts = os_facts.dup
         facts[:fqdn]   = 'myserver.test.local'
+        facts[:networking][:fqdn]   = 'myserver.test.local'
         facts[:domain] = 'host.net'
         facts
       }


### PR DESCRIPTION
This patch adds support for RockyLinux 8

The patch enforces a standardized asset baseline using simp/puppetsync,
and may also apply other updates to ensure conformity.