### PR TITLE
Remove use of FileTest.exists?

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed Oct 18 2023 Steven Pritchard <steve@sicura.us> - 6.9.1
+- Replace call to `FileTest.exists?` with `FileTest.exist?` for compatibility
+  with Ruby 3
+
 * Wed Oct 11 2023 Steven Pritchard <steve@sicura.us> - 6.9.0
 - [puppetsync] Updates for Puppet 8
   - These updates may include the following:

--- a/lib/facter/openldap_arch.rb
+++ b/lib/facter/openldap_arch.rb
@@ -6,7 +6,7 @@ Facter.add("openldap_arch") do
     setcode do
         retval = "i386"
 
-        if FileTest.exists?("/usr/sbin/slapd") then
+        if FileTest.exist?("/usr/sbin/slapd") then
 
             if ( %x{/usr/bin/file /usr/sbin/slapd} =~ /64-bit/ ) then
                 retval = "x86_64"

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_openldap",
-  "version": "6.9.0",
+  "version": "6.9.1",
   "author": "SIMP Team",
   "summary": "Manages OpenLDAP and related security bindings",
   "license": "Apache-2.0",


### PR DESCRIPTION
Replace call to `FileTest.exists?` with `FileTest.exist?` for compatibility with Ruby 3

Closes #127