### PR TITLE
[puppetsync] Support simp-iptables 7.x

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,11 +9,14 @@ fixtures:
     augeasproviders_grub: https://github.com/simp/augeasproviders_grub.git
     compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup.git
     concat: https://github.com/simp/puppetlabs-concat.git
+    firewalld: https://github.com/simp/pupmod-voxpupuli-firewalld.git
     incron: https://github.com/simp/pupmod-simp-incron.git
+    inifile: https://github.com/simp/puppetlabs-inifile
     iptables: https://github.com/simp/pupmod-simp-iptables.git
     logrotate: https://github.com/simp/pupmod-simp-logrotate.git
     pki: https://github.com/simp/pupmod-simp-pki.git
     rsyslog: https://github.com/simp/pupmod-simp-rsyslog.git
+    simp_firewalld: https://github.com/simp/pupmod-simp-simp_firewalld.git
     simp_options: https://github.com/simp/pupmod-simp-simp_options.git
     simplib: https://github.com/simp/pupmod-simp-simplib.git
     sssd: https://github.com/simp/pupmod-simp-sssd.git

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Sep 13 2024 Steven Pritchard <steve@sicura.us> - 6.11.0
+- [puppetsync] Update module dependencies to support simp-iptables 7.x
+
 * Mon Oct 23 2023 Steven Pritchard <steve@sicura.us> - 6.10.0
 - [puppetsync] Add EL9 support
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_openldap",
-  "version": "6.10.0",
+  "version": "6.11.0",
   "author": "SIMP Team",
   "summary": "Manages OpenLDAP and related security bindings",
   "license": "Apache-2.0",
@@ -24,7 +24,7 @@
     },
     {
       "name": "simp/iptables",
-      "version_requirement": ">= 6.5.3 < 7.0.0"
+      "version_requirement": ">= 6.5.3 < 8.0.0"
     },
     {
       "name": "simp/logrotate",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -100,7 +100,6 @@ RSpec.configure do |c|
   c.mock_with :rspec
 
   c.module_path = File.join(fixture_path, 'modules')
-  c.manifest_dir = File.join(fixture_path, 'manifests') if c.respond_to?(:manifest_dir)
 
   c.hiera_config = File.join(fixture_path, 'hieradata', 'hiera.yaml')
 


### PR DESCRIPTION
Update module dependencies to support simp-iptables 7.x.